### PR TITLE
create a soft link for run-parts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM node:lts-alpine
 
 RUN apk --no-cache --update add ca-certificates \
+  && ln -sf /bin/run-parts /usr/bin/run-parts \
   && update-ca-certificates
 
 EXPOSE 8080


### PR DESCRIPTION
Added symlink for run-parts to resolve `update-ca-certificates` error.